### PR TITLE
Add size field to EPUB response

### DIFF
--- a/graphql/epub_resolver.go
+++ b/graphql/epub_resolver.go
@@ -37,7 +37,7 @@ func (r *Resolver) getEpub(ctx context.Context, id string) (*model1.Epub, error)
 
 	// Check if EPUB file exists.
 	epubObj := bucket.Object(epubPath)
-	_, err = epubObj.Attrs(ctx)
+	attrs, err := epubObj.Attrs(ctx)
 
 	if err == nil {
 		// EPUB exists - generate signed URL.
@@ -46,9 +46,13 @@ func (r *Resolver) getEpub(ctx context.Context, id string) (*model1.Epub, error)
 			return nil, fmt.Errorf("failed to generate signed URL: %v", signErr)
 		}
 
+		// Convert size from int64 to *int for GraphQL.
+		size := int(attrs.Size)
+
 		return &model1.Epub{
 			ID:        id,
 			SignedURL: &signedURL,
+			Size:      &size,
 			Status:    model1.EpubStatusCompleted,
 		}, nil
 	}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -17,7 +17,6 @@ import (
 	gqlparser "github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 	lawapi "go.ngs.io/jplaw-api-v2"
-
 	"go.ngs.io/jplaw2epub-web-api/graphql/model"
 )
 
@@ -54,6 +53,7 @@ type ComplexityRoot struct {
 		Error     func(childComplexity int) int
 		ID        func(childComplexity int) int
 		SignedURL func(childComplexity int) int
+		Size      func(childComplexity int) int
 		Status    func(childComplexity int) int
 	}
 
@@ -196,6 +196,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Epub.SignedURL(childComplexity), true
+
+	case "Epub.size":
+		if e.complexity.Epub.Size == nil {
+			break
+		}
+
+		return e.complexity.Epub.Size(childComplexity), true
 
 	case "Epub.status":
 		if e.complexity.Epub.Status == nil {
@@ -976,6 +983,47 @@ func (ec *executionContext) fieldContext_Epub_signedUrl(_ context.Context, field
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Epub_size(ctx context.Context, field graphql.CollectedField, obj *model.Epub) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Epub_size(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Size, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Epub_size(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Epub",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -2492,6 +2540,8 @@ func (ec *executionContext) fieldContext_Query_epub(ctx context.Context, field g
 				return ec.fieldContext_Epub_id(ctx, field)
 			case "signedUrl":
 				return ec.fieldContext_Epub_signedUrl(ctx, field)
+			case "size":
+				return ec.fieldContext_Epub_size(ctx, field)
 			case "status":
 				return ec.fieldContext_Epub_status(ctx, field)
 			case "error":
@@ -5454,6 +5504,8 @@ func (ec *executionContext) _Epub(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "signedUrl":
 			out.Values[i] = ec._Epub_signedUrl(ctx, field, obj)
+		case "size":
+			out.Values[i] = ec._Epub_size(ctx, field, obj)
 		case "status":
 			out.Values[i] = ec._Epub_status(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -12,6 +12,7 @@ import (
 type Epub struct {
 	ID        string     `json:"id"`
 	SignedURL *string    `json:"signedUrl,omitempty"`
+	Size      *int       `json:"size,omitempty"`
 	Status    EpubStatus `json:"status"`
 	Error     *string    `json:"error,omitempty"`
 }

--- a/graphql/schema.graphqls
+++ b/graphql/schema.graphqls
@@ -212,7 +212,7 @@ type Query {
     offset: Int = 0
     sentencesLimit: Int = 10
   ): KeywordResponse!
-  
+
   epub(id: String!): Epub!
 }
 
@@ -221,6 +221,7 @@ type Query {
 type Epub {
   id: String!
   signedUrl: String
+  size: Int
   status: EpubStatus!
   error: String
 }

--- a/graphql/schema.resolvers.go
+++ b/graphql/schema.resolvers.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	lawapi "go.ngs.io/jplaw-api-v2"
-
 	model1 "go.ngs.io/jplaw2epub-web-api/graphql/model"
 )
 


### PR DESCRIPTION
## Summary
- Add file size information to EPUB GraphQL response when the file exists in GCS bucket
- The size field returns the file size in bytes as an Int type

## Changes
- Modified `getEpub` function to retrieve and include file size from GCS object attributes
- Store the `attrs` from `epubObj.Attrs(ctx)` call
- Convert size from int64 to int and include it in the response

## Test plan
- [ ] Verify that EPUB queries return size field when EPUB exists in bucket
- [ ] Confirm size is null for pending/processing EPUBs
- [ ] Test with various file sizes (ensure they're under 2GB limit of Int type)

🤖 Generated with [Claude Code](https://claude.ai/code)